### PR TITLE
Updating sequelize typescript version

### DIFF
--- a/udagram/udagram-api/package.json
+++ b/udagram/udagram-api/package.json
@@ -33,7 +33,7 @@
     "pg": "^8.7.1",
     "reflect-metadata": "^0.1.13",
     "sequelize": "^6.5.0",
-    "sequelize-typescript": "^0.6.9"
+    "sequelize-typescript": "^2.1.3"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.26",


### PR DESCRIPTION
This old version was giving an error which was:  cannot find a module v6
Fixing this issue : https://github.com/udacity/nd0067-c4-deployment-process-project-starter/issues/52