### PR TITLE
Update tsconfig.json

### DIFF
--- a/udagram/udagram-api/tsconfig.json
+++ b/udagram/udagram-api/tsconfig.json
@@ -60,6 +60,7 @@
     /* Experimental Options */
     "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "skipLibCheck": true  
   },
     "include": [
         "src/**/*"


### PR DESCRIPTION
 please add this prop  ("skipLibCheck": true) because there is annoying error (node_modules/class-validator/validation/Validator.d.ts:383:38 - error TS2503: Cannot find namespace 'ValidatorJS'.)